### PR TITLE
Bugfix for ignored {pre|post}{create|modify|remove} hooks from gosa.conf

### DIFF
--- a/include/class_configRegistry.inc
+++ b/include/class_configRegistry.inc
@@ -336,7 +336,7 @@ class configRegistry{
                             
                             if(!in_array_strict($name, array('CLASS','NAME'))){
                                 $class= $info['CLASS'];    
-                                $this->fileStoredProperties[$class][strtolower($name)] = $value;
+                                $this->fileStoredProperties[strtolower($class)][strtolower($name)] = $value;
                             }
                         }
                     }


### PR DESCRIPTION
This fixes a bug where properties stored in gosa.conf did not take effect.  The
reason was data being put into the fileStoredProperties array using keys with
capital letters (for example 'posixAccount') while every lookup was being done
using lowercased keys.
